### PR TITLE
Fixing the second link to the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ integrate(x -> 6x^5, opq)
 ```
 
 
-For more information please visit the [documentation](https://timueh.github.io/PolyChaos.jl/stable/).
+For more information please visit the [documentation](https://polychaos.sciml.ai/stable).
 
 ## Citing
 


### PR DESCRIPTION
The second link to the documentation still pointed to the old website. Now points to the new site hosted at sciml.ai .

As this was a simple issue in the README i did not open an issue. I hope that that is okay. 
