### PR TITLE
Change `Tensor`'s inner constructor methods to outer

### DIFF
--- a/src/typesTensor.jl
+++ b/src/typesTensor.jl
@@ -5,17 +5,14 @@ struct Tensor{OP} <: AbstractTensor{OP}
     T::SparseVector{Float64, Int}
     get::Function
     op::OP
-
-    # inner constructors
-    function Tensor(dim::Int, mop::MultiOrthoPoly)
-        tensorEntries = computeTensorizedSP(dim, mop)
-        getfun(ind) = getentry(ind, tensorEntries, mop.ind, dim)
-        new{typeof(mop)}(dim, tensorEntries, getfun, mop)
-    end
-
-    function Tensor(dim::Int, opq::AbstractOrthoPoly)
-        tensorEntries = computeTensorizedSP(dim, opq)
-        getfun(ind) = getentry(ind, tensorEntries, calculateMultiIndices(1, opq.deg), dim)
-        new{typeof(opq)}(dim, tensorEntries, getfun, opq)
-    end
+end
+function Tensor(dim::Int, mop::MultiOrthoPoly)
+    tensorEntries = computeTensorizedSP(dim, mop)
+    getfun(ind) = getentry(ind, tensorEntries, mop.ind, dim)
+    Tensor(dim, tensorEntries, getfun, mop)
+end
+function Tensor(dim::Int, opq::AbstractOrthoPoly)
+    tensorEntries = computeTensorizedSP(dim, opq)
+    getfun(ind) = getentry(ind, tensorEntries, calculateMultiIndices(1, opq.deg), dim)
+    Tensor(dim, tensorEntries, getfun, opq)
 end


### PR DESCRIPTION
To allow customized construction of `Tensor` in downstream.