### PR TITLE
Use approximate comparison to test floating-point results

### DIFF
--- a/test/auxfuns.jl
+++ b/test/auxfuns.jl
@@ -67,7 +67,7 @@ nodes, weights = SVector(op.quad.nodes...), SVector(op.quad.weights...)
 
 myfun(t) = t^2
 
-@test integrate(myfun, op) == integrate(myfun, nodes, weights)
+@test integrate(myfun, op) ≈ integrate(myfun, nodes, weights)
 
 n_multi = 4
 mop = MultiOrthoPoly([op for i in 1:n_multi], max_degree)


### PR DESCRIPTION
The CI randomly fails because
```julia
julia> 0.3333333333333338 == 0.33333333333333376
false
```