### PR TITLE
Faster polynomial evaluation

### DIFF
--- a/src/auxfuns.jl
+++ b/src/auxfuns.jl
@@ -130,8 +130,8 @@ function getentry(a::AbstractVector{<:Int}, T::SparseVector{<:Real, <:Int},
     m != dim && throw(DomainError(m,
                       "length $m of provided index $a is inconsistent with dimension $(dim) of multi-index"))
     # a .+= 1
-    sort!(a)
+    sort!(a; rev = true)
 
-    sp_ind = 1 + reduce(+, [idx * l^(m - i) for (i, idx) in enumerate(a)])
+    sp_ind = 1 + evalpoly(l, a)
     return T[sp_ind]
 end

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -10,7 +10,11 @@ function computeTensorizedSP(m::Integer,
     m < 1 && throw(DomainError(m, "`dimension` has to be positive"))
     l, p = size(ind)
     l -= 1
-    T = spzeros(reduce(+, [l^i for i in 0:m]))
+    s = 1
+    for _ in 1:m
+        s = muladd(s, l, 1)
+    end
+    T = spzeros(s)
     for tensor_ind in with_replacement_combinations(0:l, m)
         index = 1 + evalpoly(l, reverse!(tensor_ind))
         T[index] = computeSP(tensor_ind, α, β, nodes, weights, ind;

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -11,8 +11,8 @@ function computeTensorizedSP(m::Integer,
     l, p = size(ind)
     l -= 1
     T = spzeros(reduce(+, [l^i for i in 0:m]))
-    for tensor_ind in collect(with_replacement_combinations(0:l, m))
-        index = 1 + reduce(+, [idx * l^(m - i) for (i, idx) in enumerate(tensor_ind)])
+    for tensor_ind in with_replacement_combinations(0:l, m)
+        index = 1 + evalpoly(l, reverse!(tensor_ind))
         T[index] = computeSP(tensor_ind, α, β, nodes, weights, ind;
                              issymmetric = issymmetric)
     end


### PR DESCRIPTION
```julia
using BenchmarkTools: @btime
m = 50
l = 2
a = rand(2:4, m)
f1(l, a) = 1 + reduce(+, [idx * l^(m - i) for (i, idx) in enumerate(a)])
f2(l, a) = 1 + evalpoly(l, a)
@show f1(l, a) == f2(l, reverse(a)) # true
@btime f1($(Ref(l))[], $a)            # 3.787 μs (89 allocations: 1.89 KiB)
@btime f2($(Ref(l))[], $(reverse(a))) # 43.352 ns (0 allocations: 0 bytes)
```

Reference:
- [`evalpoly`](https://docs.julialang.org/en/v1.8/base/math/#Base.Math.evalpoly)
- [Horner's method](https://en.wikipedia.org/wiki/Horner%27s_method)