### PR TITLE
Construct OrthoPoly from corresponding measure

### DIFF
--- a/src/typesOrthoPolys.jl
+++ b/src/typesOrthoPolys.jl
@@ -125,7 +125,7 @@ function JacobiOrthoPoly(deg::Int, shape_a::Real, shape_b::Real; Nrec::Int = deg
 end
 
 function OrthoPoly(μ::JacobiMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    JacobiOrthoPoly(deg, μ.ashapeParamter, μ.bshapeParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+    JacobiOrthoPoly(deg, μ.ashapeParameter, μ.bshapeParameter; Nrec=Nrec, addQuadrature=addQuadrature)
 end
 
 struct LaguerreOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -221,8 +221,8 @@ end
 
 struct MeixnerPollaczekOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
     deg::Int          # maximum degree
-    α::V  # recurrence coefficients
-    β::V  # recurrence coefficients
+    α::V              # recurrence coefficients
+    β::V              # recurrence coefficients
     measure::M
     quad::Q
 end
@@ -352,7 +352,7 @@ function GammaOrthoPoly(deg::Int, shape::Real, rate::Real; Nrec::Int = deg + 1,
                                                                                          quadrature)
 end
 
-function OrthoPoly(μ::GammaOrthoPoly, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
+function OrthoPoly(μ::GammaMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
     GammaOrthoPoly(deg, μ.shapeParameter, μ.rateParameter; Nrec=Nrec, addQuadrature=addQuadrature)
 end
 

--- a/src/typesOrthoPolys.jl
+++ b/src/typesOrthoPolys.jl
@@ -45,10 +45,11 @@ function OrthoPoly(name::String, deg::Int, α::AbstractVector{<:Real},
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
     # @show types = promote_type(eltype(α), eltype(β)), promote_type(typeof(α), typeof(β)), typeof(measure), typeof(quadrature)
     OrthoPoly{promote_type(typeof(α), typeof(β)), typeof(measure), typeof(quadrature)}(lowercase(name),
-                                                                                        deg, α,
-                                                                                        β,
-                                                                                        measure,
-                                                                                        quadrature)
+                                                                                       deg,
+                                                                                       α,
+                                                                                       β,
+                                                                                       measure,
+                                                                                       quadrature)
 end
 
 # constructor for known Measure
@@ -63,10 +64,10 @@ function OrthoPoly(name::String, deg::Int, measure::AbstractMeasure; Nrec = deg 
 end
 
 function OrthoPoly(μ::Measure, deg::Int; Nrec = deg + 1, Nquad = 10 * Nrec,
-                                         quadrature::Function = clenshaw_curtis,
-    discretization::Function = stieltjes, addQuadrature::Bool = true)
-    OrthoPoly(μ.name, deg, μ; Nrec=Nrec, Nquad=Nquad, quadrature=quadrature,
-                              discretization=discretization, addQuadrature=addQuadrature)
+                   quadrature::Function = clenshaw_curtis,
+                   discretization::Function = stieltjes, addQuadrature::Bool = true)
+    OrthoPoly(μ.name, deg, μ; Nrec = Nrec, Nquad = Nquad, quadrature = quadrature,
+              discretization = discretization, addQuadrature = addQuadrature)
 end
 
 # general constructor
@@ -94,14 +95,16 @@ function LegendreOrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = 
     _checkConsistency(deg, Nrec)
     α, β = rm_legendre(Nrec)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    LegendreOrthoPoly{promote_type(typeof(α), typeof(β)), LegendreMeasure, typeof(quadrature)}(deg, α,
-                                                                                               β,
-                                                                                               LegendreMeasure(),
-                                                                                               quadrature)
+    LegendreOrthoPoly{promote_type(typeof(α), typeof(β)), LegendreMeasure,
+                      typeof(quadrature)}(deg, α,
+                                          β,
+                                          LegendreMeasure(),
+                                          quadrature)
 end
 
-function OrthoPoly(::LegendreMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    LegendreOrthoPoly(deg; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::LegendreMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    LegendreOrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct JacobiOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -117,15 +120,18 @@ function JacobiOrthoPoly(deg::Int, shape_a::Real, shape_b::Real; Nrec::Int = deg
     _checkConsistency(deg, Nrec)
     α, β = rm_jacobi(Nrec, shape_a, shape_b)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    JacobiOrthoPoly{promote_type(typeof(α), typeof(β)), JacobiMeasure, typeof(quadrature)}(deg, α,
+    JacobiOrthoPoly{promote_type(typeof(α), typeof(β)), JacobiMeasure, typeof(quadrature)}(deg,
+                                                                                           α,
                                                                                            β,
                                                                                            JacobiMeasure(shape_a,
                                                                                                          shape_b),
                                                                                            quadrature)
 end
 
-function OrthoPoly(μ::JacobiMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    JacobiOrthoPoly(deg, μ.ashapeParameter, μ.bshapeParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(μ::JacobiMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    JacobiOrthoPoly(deg, μ.ashapeParameter, μ.bshapeParameter; Nrec = Nrec,
+                    addQuadrature = addQuadrature)
 end
 
 struct LaguerreOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -140,14 +146,16 @@ function LaguerreOrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = 
     _checkConsistency(deg, Nrec)
     α, β = rm_laguerre(Nrec)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    LaguerreOrthoPoly{promote_type(typeof(α), typeof(β)), LaguerreMeasure, typeof(quadrature)}(deg, α,
-                                                                                               β,
-                                                                                               LaguerreMeasure(),
-                                                                                               quadrature)
+    LaguerreOrthoPoly{promote_type(typeof(α), typeof(β)), LaguerreMeasure,
+                      typeof(quadrature)}(deg, α,
+                                          β,
+                                          LaguerreMeasure(),
+                                          quadrature)
 end
 
-function OrthoPoly(::LaguerreMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    LaguerreOrthoPoly(deg; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::LaguerreMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    LaguerreOrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct genLaguerreOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -163,15 +171,17 @@ function genLaguerreOrthoPoly(deg::Int, shape::Real; Nrec::Int = deg + 1,
     _checkConsistency(deg, Nrec)
     α, β = rm_laguerre(Nrec, shape)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    genLaguerreOrthoPoly{promote_type(typeof(α), typeof(β)), genLaguerreMeasure, typeof(quadrature)}(deg,
-                                                                                                    α,
-                                                                                                    β,
-                                                                                                    genLaguerreMeasure(shape),
-                                                                                                    quadrature)
+    genLaguerreOrthoPoly{promote_type(typeof(α), typeof(β)), genLaguerreMeasure,
+                         typeof(quadrature)}(deg,
+                                             α,
+                                             β,
+                                             genLaguerreMeasure(shape),
+                                             quadrature)
 end
 
-function OrthoPoly(μ::genLaguerreMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    genLaguerreOrthoPoly(deg, μ.shapeParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(μ::genLaguerreMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    genLaguerreOrthoPoly(deg, μ.shapeParameter; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct HermiteOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -186,14 +196,16 @@ function HermiteOrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = t
     _checkConsistency(deg, Nrec)
     α, β = rm_hermite(Nrec)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    HermiteOrthoPoly{promote_type(typeof(α), typeof(β)), HermiteMeasure, typeof(quadrature)}(deg, α,
-                                                                                             β,
-                                                                                             HermiteMeasure(),
-                                                                                             quadrature)
+    HermiteOrthoPoly{promote_type(typeof(α), typeof(β)), HermiteMeasure, typeof(quadrature)
+                     }(deg, α,
+                       β,
+                       HermiteMeasure(),
+                       quadrature)
 end
 
-function OrthoPoly(::HermiteMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    HermiteOrthoPoly(deg; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::HermiteMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    HermiteOrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct genHermiteOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -205,18 +217,20 @@ struct genHermiteOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
 end
 
 function genHermiteOrthoPoly(deg::Int, mu::Real; Nrec::Int = deg + 1,
-    addQuadrature::Bool = true)
+                             addQuadrature::Bool = true)
     _checkConsistency(deg, Nrec)
     α, β = rm_hermite(Nrec, mu)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    genHermiteOrthoPoly{promote_type(typeof(α), typeof(β)), genHermiteMeasure, typeof(quadrature)}(deg,
-                                                                                                   α, β,
-                                                                                                   genHermiteMeasure(mu),
-                                                                                                   quadrature)
+    genHermiteOrthoPoly{promote_type(typeof(α), typeof(β)), genHermiteMeasure,
+                        typeof(quadrature)}(deg,
+                                            α, β,
+                                            genHermiteMeasure(mu),
+                                            quadrature)
 end
 
-function OrthoPoly(μ::genHermiteMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    genHermiteOrthoPoly(deg, μ.muParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(μ::genHermiteMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    genHermiteOrthoPoly(deg, μ.muParameter; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct MeixnerPollaczekOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -232,15 +246,18 @@ function MeixnerPollaczekOrthoPoly(deg::Int, λ::Real, ϕ::Real; Nrec::Int = deg
     _checkConsistency(deg, Nrec)
     α, β = rm_meixner_pollaczek(Nrec, λ, ϕ)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    MeixnerPollaczekOrthoPoly{promote_type(typeof(α), typeof(β)), MeixnerPollaczekMeasure, typeof(quadrature)}(deg, 
-                                                                                                               α, 
-                                                                                                               β, 
-                                                                                                               MeixnerPollaczekMeasure(λ, ϕ),
-                                                                                                               quadrature)
+    MeixnerPollaczekOrthoPoly{promote_type(typeof(α), typeof(β)), MeixnerPollaczekMeasure,
+                              typeof(quadrature)}(deg,
+                                                  α,
+                                                  β,
+                                                  MeixnerPollaczekMeasure(λ, ϕ),
+                                                  quadrature)
 end
 
-function OrthoPoly(μ::MeixnerPollaczekMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    MeixnerPollaczekOrthoPoly(deg, μ.λParameter, μ.ϕParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(μ::MeixnerPollaczekMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    MeixnerPollaczekOrthoPoly(deg, μ.λParameter, μ.ϕParameter; Nrec = Nrec,
+                              addQuadrature = addQuadrature)
 end
 
 struct GaussOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -255,13 +272,16 @@ function GaussOrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = tru
     _checkConsistency(deg, Nrec)
     α, β = r_scale(1 / sqrt(2pi), rm_hermite_prob(Nrec)...)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    GaussOrthoPoly{promote_type(typeof(α), typeof(β)), GaussMeasure, typeof(quadrature)}(deg, α, β,
+    GaussOrthoPoly{promote_type(typeof(α), typeof(β)), GaussMeasure, typeof(quadrature)}(deg,
+                                                                                         α,
+                                                                                         β,
                                                                                          GaussMeasure(),
                                                                                          quadrature)
 end
 
-function OrthoPoly(::GaussMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    GaussOrthoPoly(deg; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::GaussMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    GaussOrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct Uniform01OrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -269,21 +289,23 @@ struct Uniform01OrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
     α::V  # recurrence coefficients
     β::V  # recurrence coefficients
     measure::M
-    quad::Q    
+    quad::Q
 end
 
 function Uniform01OrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
     _checkConsistency(deg, Nrec)
     α, β = r_scale(1.0, rm_legendre01(Nrec)...)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    Uniform01OrthoPoly{promote_type(typeof(α), typeof(β)), Uniform01Measure, typeof(quadrature)}(deg,
-                                                                                                 α, β,
-                                                                                                 Uniform01Measure(),
-                                                                                                 quadrature)
+    Uniform01OrthoPoly{promote_type(typeof(α), typeof(β)), Uniform01Measure,
+                       typeof(quadrature)}(deg,
+                                           α, β,
+                                           Uniform01Measure(),
+                                           quadrature)
 end
 
-function OrthoPoly(::Uniform01Measure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    Uniform01OrthoPoly(deg; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::Uniform01Measure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    Uniform01OrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct Uniform_11OrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -298,14 +320,16 @@ function Uniform_11OrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool 
     _checkConsistency(deg, Nrec)
     α, β = r_scale(0.5, rm_legendre(Nrec)...)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    Uniform_11OrthoPoly{promote_type(typeof(α), typeof(β)), Uniform_11Measure, typeof(quadrature)}(deg,
-                                                                                                   α, β,
-                                                                                                   Uniform_11Measure(),
-                                                                                                   quadrature)
+    Uniform_11OrthoPoly{promote_type(typeof(α), typeof(β)), Uniform_11Measure,
+                        typeof(quadrature)}(deg,
+                                            α, β,
+                                            Uniform_11Measure(),
+                                            quadrature)
 end
 
-function OrthoPoly(::Uniform_11Measure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    Uniform_11OrthoPoly(deg; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::Uniform_11Measure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    Uniform_11OrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 struct Beta01OrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -320,17 +344,20 @@ function Beta01OrthoPoly(deg::Int, shape_a::Real, shape_b::Real; Nrec::Int = deg
                          addQuadrature::Bool = true)
     _checkConsistency(deg, Nrec)
     α, β = r_scale(1 / beta(shape_a, shape_b),
-    rm_jacobi01(Nrec, shape_b - 1.0, shape_a - 1.0)...)
+                   rm_jacobi01(Nrec, shape_b - 1.0, shape_a - 1.0)...)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    Beta01OrthoPoly{promote_type(typeof(α), typeof(β)), Beta01Measure, typeof(quadrature)}(deg, α,
+    Beta01OrthoPoly{promote_type(typeof(α), typeof(β)), Beta01Measure, typeof(quadrature)}(deg,
+                                                                                           α,
                                                                                            β,
                                                                                            Beta01Measure(shape_a,
-                                                                                           shape_b),
+                                                                                                         shape_b),
                                                                                            quadrature)
 end
 
-function OrthoPoly(μ::Beta01Measure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    Beta01OrthoPoly(deg, μ.ashapeParameter, μ.bshapeParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(μ::Beta01Measure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    Beta01OrthoPoly(deg, μ.ashapeParameter, μ.bshapeParameter; Nrec = Nrec,
+                    addQuadrature = addQuadrature)
 end
 
 struct GammaOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -342,18 +369,22 @@ struct GammaOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
 end
 
 function GammaOrthoPoly(deg::Int, shape::Real, rate::Real; Nrec::Int = deg + 1,
-                                                           addQuadrature::Bool = true)
+                        addQuadrature::Bool = true)
     _checkConsistency(deg, Nrec)
     α, β = r_scale((rate^shape) / gamma(shape), rm_laguerre(Nrec, shape - 1.0)...)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    GammaOrthoPoly{promote_type(typeof(α), typeof(β)), GammaMeasure, typeof(quadrature)}(deg, α, β,
+    GammaOrthoPoly{promote_type(typeof(α), typeof(β)), GammaMeasure, typeof(quadrature)}(deg,
+                                                                                         α,
+                                                                                         β,
                                                                                          GammaMeasure(shape,
                                                                                                       rate),
                                                                                          quadrature)
 end
 
-function OrthoPoly(μ::GammaMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    GammaOrthoPoly(deg, μ.shapeParameter, μ.rateParameter; Nrec=Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(μ::GammaMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    GammaOrthoPoly(deg, μ.shapeParameter, μ.rateParameter; Nrec = Nrec,
+                   addQuadrature = addQuadrature)
 end
 
 struct LogisticOrthoPoly{V, M, Q} <: AbstractCanonicalOrthoPoly{V, M, Q}
@@ -368,14 +399,16 @@ function LogisticOrthoPoly(deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = 
     _checkConsistency(deg, Nrec)
     α, β = r_scale(1.0, rm_logistic(Nrec)...)
     quadrature = addQuadrature ? Quad(length(α) - 1, α, β) : EmptyQuad()
-    LogisticOrthoPoly{promote_type(typeof(α), typeof(β)), LogisticMeasure, typeof(quadrature)}(deg, α,
-                                                                                               β,
-                                                                                               LogisticMeasure(),
-                                                                                               quadrature)
+    LogisticOrthoPoly{promote_type(typeof(α), typeof(β)), LogisticMeasure,
+                      typeof(quadrature)}(deg, α,
+                                          β,
+                                          LogisticMeasure(),
+                                          quadrature)
 end
 
-function OrthoPoly(::LogisticMeasure, deg::Int; Nrec::Int = deg + 1, addQuadrature::Bool = true)
-    LogisticOrthoPoly(deg; Nrec = Nrec, addQuadrature=addQuadrature)
+function OrthoPoly(::LogisticMeasure, deg::Int; Nrec::Int = deg + 1,
+                   addQuadrature::Bool = true)
+    LogisticOrthoPoly(deg; Nrec = Nrec, addQuadrature = addQuadrature)
 end
 
 # #####################################################

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,0 +1,143 @@
+using PolyChaos, Test
+
+
+deg = 4
+Nrec = 10
+
+
+function compare_quad(A::Quad,B::Quad)
+    (A.Nquad == B.Nquad) && (A.name == B.name) && (A.nodes == B.nodes) && (A.weights == B.weights)
+end
+
+function compare_quad(A::EmptyQuad,B::EmptyQuad)
+    true
+end
+
+function compare_orthopoly(A, B)
+    (A.deg == B.deg) && compare_quad(A.quad, B.quad) && (A.measure == B.measure) && (A.α == B.α) && (A.β == B.β)
+end
+
+
+@testset "LegendreOrthoPoly constructors" begin 
+    meas = LegendreMeasure()
+    for quad in [true, false]
+        polyA = LegendreOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "JacobiOrthoPoly constructors" begin 
+    shape_a, shape_b = rand(), rand()
+    meas = JacobiMeasure(shape_a,shape_b)
+    for quad in [true, false]
+        polyA = JacobiOrthoPoly(deg, shape_a, shape_b, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "LaguerreOrthoPoly constructors" begin 
+    meas = LaguerreMeasure()
+    for quad in [true, false]
+        polyA = LaguerreOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "genLaguerreOrthoPoly constructors" begin 
+    shape = rand()
+    meas = genLaguerreMeasure(shape)
+    for quad in [true, false]
+        polyA = genLaguerreOrthoPoly(deg, shape, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "HermiteOrthoPoly constructors" begin 
+    meas = HermiteMeasure()
+    for quad in [true, false]
+        polyA = HermiteOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+
+@testset "genHermiteOrthoPoly constructors" begin 
+    mu = rand()
+    meas = genHermiteMeasure(mu)
+    for quad in [true, false]
+        polyA = genHermiteOrthoPoly(deg, mu, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "MeixnerPollaczekOrthoPoly constructors" begin 
+    lambda, phi = rand(), rand()
+    meas = MeixnerPollaczekMeasure(lambda, phi)
+    for quad in [true, false]
+        polyA = MeixnerPollaczekOrthoPoly(deg, lambda, phi, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "GaussOrthoPoly constructors" begin 
+    meas = GaussMeasure()
+    for quad in [true, false]
+        polyA = GaussOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "Uniform01OrthoPoly constructors" begin 
+    meas = Uniform01Measure()
+    for quad in [true, false]
+        polyA = Uniform01OrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "Uniform_11OrthoPoly constructors" begin 
+    meas = Uniform_11Measure()
+    for quad in [true, false]
+        polyA = Uniform_11OrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "Beta01OrthoPoly constructors" begin 
+    shape_a, shape_b = rand(), rand()
+    meas = Beta01Measure(shape_a, shape_b)
+    for quad in [true, false]
+        polyA = Beta01OrthoPoly(deg, shape_a, shape_b, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "GammaOrthoPoly constructors" begin 
+    shape, rate = rand(), 1.0
+    meas = GammaMeasure(shape, rate)
+    for quad in [true, false]
+        polyA = GammaOrthoPoly(deg, shape, rate, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 
+
+@testset "LogisticOrthoPoly constructors" begin 
+    meas = LogisticMeasure()
+    for quad in [true, false]
+        polyA = LogisticOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
+        polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
+        @test compare_orthopoly(polyA, polyB)
+    end
+end 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,52 +1,51 @@
 using PolyChaos, Test
 
-
 deg = 4
 Nrec = 10
 
-
-function compare_quad(A::Quad,B::Quad)
-    (A.Nquad == B.Nquad) && (A.name == B.name) && (A.nodes == B.nodes) && (A.weights == B.weights)
+function compare_quad(A::Quad, B::Quad)
+    (A.Nquad == B.Nquad) && (A.name == B.name) && (A.nodes == B.nodes) &&
+        (A.weights == B.weights)
 end
 
-function compare_quad(A::EmptyQuad,B::EmptyQuad)
+function compare_quad(A::EmptyQuad, B::EmptyQuad)
     true
 end
 
 function compare_orthopoly(A, B)
-    (A.deg == B.deg) && compare_quad(A.quad, B.quad) && (A.measure == B.measure) && (A.α == B.α) && (A.β == B.β)
+    (A.deg == B.deg) && compare_quad(A.quad, B.quad) && (A.measure == B.measure) &&
+        (A.α == B.α) && (A.β == B.β)
 end
 
-
-@testset "LegendreOrthoPoly constructors" begin 
+@testset "LegendreOrthoPoly constructors" begin
     meas = LegendreMeasure()
     for quad in [true, false]
         polyA = LegendreOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "JacobiOrthoPoly constructors" begin 
+@testset "JacobiOrthoPoly constructors" begin
     shape_a, shape_b = rand(), rand()
-    meas = JacobiMeasure(shape_a,shape_b)
+    meas = JacobiMeasure(shape_a, shape_b)
     for quad in [true, false]
         polyA = JacobiOrthoPoly(deg, shape_a, shape_b, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "LaguerreOrthoPoly constructors" begin 
+@testset "LaguerreOrthoPoly constructors" begin
     meas = LaguerreMeasure()
     for quad in [true, false]
         polyA = LaguerreOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "genLaguerreOrthoPoly constructors" begin 
+@testset "genLaguerreOrthoPoly constructors" begin
     shape = rand()
     meas = genLaguerreMeasure(shape)
     for quad in [true, false]
@@ -54,19 +53,18 @@ end
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "HermiteOrthoPoly constructors" begin 
+@testset "HermiteOrthoPoly constructors" begin
     meas = HermiteMeasure()
     for quad in [true, false]
         polyA = HermiteOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-
-@testset "genHermiteOrthoPoly constructors" begin 
+@testset "genHermiteOrthoPoly constructors" begin
     mu = rand()
     meas = genHermiteMeasure(mu)
     for quad in [true, false]
@@ -74,9 +72,9 @@ end
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "MeixnerPollaczekOrthoPoly constructors" begin 
+@testset "MeixnerPollaczekOrthoPoly constructors" begin
     lambda, phi = rand(), rand()
     meas = MeixnerPollaczekMeasure(lambda, phi)
     for quad in [true, false]
@@ -84,36 +82,36 @@ end
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "GaussOrthoPoly constructors" begin 
+@testset "GaussOrthoPoly constructors" begin
     meas = GaussMeasure()
     for quad in [true, false]
         polyA = GaussOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "Uniform01OrthoPoly constructors" begin 
+@testset "Uniform01OrthoPoly constructors" begin
     meas = Uniform01Measure()
     for quad in [true, false]
         polyA = Uniform01OrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "Uniform_11OrthoPoly constructors" begin 
+@testset "Uniform_11OrthoPoly constructors" begin
     meas = Uniform_11Measure()
     for quad in [true, false]
         polyA = Uniform_11OrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "Beta01OrthoPoly constructors" begin 
+@testset "Beta01OrthoPoly constructors" begin
     shape_a, shape_b = rand(), rand()
     meas = Beta01Measure(shape_a, shape_b)
     for quad in [true, false]
@@ -121,9 +119,9 @@ end
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "GammaOrthoPoly constructors" begin 
+@testset "GammaOrthoPoly constructors" begin
     shape, rate = rand(), 1.0
     meas = GammaMeasure(shape, rate)
     for quad in [true, false]
@@ -131,13 +129,13 @@ end
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end
 
-@testset "LogisticOrthoPoly constructors" begin 
+@testset "LogisticOrthoPoly constructors" begin
     meas = LogisticMeasure()
     for quad in [true, false]
         polyA = LogisticOrthoPoly(deg, Nrec = 10, addQuadrature = quad)
         polyB = OrthoPoly(meas, deg; Nrec = 10, addQuadrature = quad)
         @test compare_orthopoly(polyA, polyB)
     end
-end 
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+include("constructors.jl")
 include("quadrature.jl")
 include("recurrence_coefficients.jl")
 include("discretization.jl")


### PR DESCRIPTION
In https://github.com/SciML/ModelOrderReduction.jl/pull/27 we would like to construct `CanonicalOrthoPoly`s and generic `OrthoPoly`s from the corresponding `Measure`s. This PR seeks to enable that by defining suitable constructors. Also, it changes the inner constructors to outer to promote extensibility. 

Best,
Flemming 