### PR TITLE
Remove outdated Julia version checks

### DIFF
--- a/src/typesOrthoPolys.jl
+++ b/src/typesOrthoPolys.jl
@@ -436,13 +436,8 @@ struct MultiOrthoPoly{M, Q, V <: AbstractVector} <: AbstractOrthoPoly{M, Q}
         measures = [op.measure for op in uniOrthoPolys]
         measure = ProductMeasure(w, measures)
 
-        names = if VERSION >= v"1.2.0"
-            [hasfield(typeof(op), :name) ? op.name : string(typeof(op))
-             for op in uniOrthoPolys]
-        else
-            [:name in fieldnames(typeof(op)) ? op.name : string(typeof(op))
-             for op in uniOrthoPolys]
-        end
+        names = [hasfield(typeof(op), :name) ? op.name : string(typeof(op))
+                 for op in uniOrthoPolys]
         ind = calculateMultiIndices(length(uniOrthoPolys), deg)
         dim = size(ind, 1)
 

--- a/test/auxfuns.jl
+++ b/test/auxfuns.jl
@@ -87,14 +87,12 @@ tensor_dim = 2
 tensor_entries = computeTensorizedSP(tensor_dim, mop)
 my_getentry(row, entries) = getentry(row, tensor_entries, entries, tensor_dim)
 
-if VERSION >= VersionNumber("1.1.1")
-    @testset "getentry for StaticArrays" begin
-        for row in eachrow(rand(0:(L - 1), L,
-            tensor_dim))
-            reference = my_getentry(Vector(row), mop.ind)
-            @test my_getentry(row, mop.ind) == reference
-            @test my_getentry(row, SMatrix{size(mop.ind)...}(mop.ind)) == reference
-            @test my_getentry(Vector(row), SMatrix{size(mop.ind)...}(mop.ind)) == reference
-        end
+@testset "getentry for StaticArrays" begin
+    for row in eachrow(rand(0:(L - 1), L,
+        tensor_dim))
+        reference = my_getentry(Vector(row), mop.ind)
+        @test my_getentry(row, mop.ind) == reference
+        @test my_getentry(row, SMatrix{size(mop.ind)...}(mop.ind)) == reference
+        @test my_getentry(Vector(row), SMatrix{size(mop.ind)...}(mop.ind)) == reference
     end
 end

--- a/test/evaluate.jl
+++ b/test/evaluate.jl
@@ -78,13 +78,11 @@ combinations = Iterators.product([α, αs], [β, βs])
                    evaluate(mop.ind, x, a, b)
              for (a, b) in combinations]
         end
-        if VERSION >= VersionNumber("1.1.1")
-            for d in eachrow(mop.ind[1:3, :])
-                [@test evaluate(collect(d), x, a, b) == evaluate(collect(d), x, mop)
-                 for (a, b) in combinations]
-                [@test evaluate(d, x, a, b) == evaluate(collect(d), x, mop)
-                 for (a, b) in combinations]
-            end
+        for d in eachrow(mop.ind[1:3, :])
+            [@test evaluate(collect(d), x, a, b) == evaluate(collect(d), x, mop)
+             for (a, b) in combinations]
+            [@test evaluate(d, x, a, b) == evaluate(collect(d), x, mop)
+             for (a, b) in combinations]
         end
     end
 end


### PR DESCRIPTION
## Summary
Since Julia v1.10 is now the LTS, version checks for v1.1.1 and v1.2.0 are no longer needed.

## Changes
- Removed v1.2.0 check in src/typesOrthoPolys.jl for hasfield vs fieldnames (now always uses hasfield)
- Removed v1.1.1 check in test/evaluate.jl for row evaluation tests
- Removed v1.1.1 check in test/auxfuns.jl for StaticArrays tests

## Test plan
- [ ] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)