### PR TITLE
Canonicalize test units with @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ Pkg = "1"
 SparseArrays = "1"
 Test = "1"
 QuadGK = "2.4"
+SafeTestsets = "0.1, 1"
 SpecialFunctions = "1, 2"
 StaticArrays = "0.12, 1.0"
 Statistics = "1"
@@ -35,8 +36,9 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Pkg", "StaticArrays", "Test"]
+test = ["Aqua", "Pkg", "SafeTestsets", "StaticArrays", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,25 @@
 using Pkg
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
 if GROUP == "All" || GROUP == "Core"
-    include("constructors.jl")
-    include("quadrature.jl")
-    include("recurrence_coefficients.jl")
-    include("discretization.jl")
-    include("logistic.jl")
-    include("comparison_gaussquadrature.jl")
-    include("quadrature_rules.jl")
-    include("show.jl")
-    include("types.jl")
-    include("auxfuns.jl")
-    include("densities.jl")
-    include("polynomial_chaos.jl")
-    include("inverse_transform_sampling.jl")
-    include("multi_indices.jl")
-    include("scalarproducts.jl")
-    include("evaluate.jl")
+    @safetestset "Constructors" begin include("constructors.jl") end
+    @safetestset "Quadrature" begin include("quadrature.jl") end
+    @safetestset "Recurrence Coefficients" begin include("recurrence_coefficients.jl") end
+    @safetestset "Discretization" begin include("discretization.jl") end
+    @safetestset "Logistic" begin include("logistic.jl") end
+    @safetestset "Comparison Gauss Quadrature" begin include("comparison_gaussquadrature.jl") end
+    @safetestset "Quadrature Rules" begin include("quadrature_rules.jl") end
+    @safetestset "Show" begin include("show.jl") end
+    @safetestset "Types" begin include("types.jl") end
+    @safetestset "Auxiliary Functions" begin include("auxfuns.jl") end
+    @safetestset "Densities" begin include("densities.jl") end
+    @safetestset "Polynomial Chaos" begin include("polynomial_chaos.jl") end
+    @safetestset "Inverse Transform Sampling" begin include("inverse_transform_sampling.jl") end
+    @safetestset "Multi Indices" begin include("multi_indices.jl") end
+    @safetestset "Scalar Products" begin include("scalarproducts.jl") end
+    @safetestset "Evaluate" begin include("evaluate.jl") end
 end
 
 if GROUP == "All" || GROUP == "QA"


### PR DESCRIPTION
## What

Wraps each independent Core test unit in `test/runtests.jl` in `@safetestset "name" begin include("x.jl") end` so every unit runs in its own fresh module — isolation between tests and world-age safety, matching the canonical OrdinaryDiffEq structure.

Before each unit was `include("x.jl")`, which ran every file into the shared `Main` module (so files silently shared/leaked imports and global names). Each included file already carries its own `using`/`import` lines at the top, so the bodies are already self-contained; this PR just wraps the `include()` calls.

## Behavior preserved
- Same 16 Core files run, in the same order, under the same GROUP.
- GROUP dispatch ladder and the QA group (`qa.jl`, a flat `Aqua.test_*` sequence in its own activated env) are unchanged.
- No assertions changed.
- Adds `SafeTestsets` to the test deps (`[extras]` / `[targets].test` + `[compat] SafeTestsets = "0.1, 1"`).

## Verification
Verified locally with Julia 1.11: `GROUP=Core julia --project Pkg.test()` — all 16 `@safetestset` units pass (Types 3427, Polynomial Chaos 4950, Scalar Products 810, Evaluate 164, etc.). No package-macro gotchas: the StaticArrays usages are the `SVector(...)` constructor (a function call), not the `@SVector` macro, so they expand correctly inside the safetestset modules.

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)