### PR TITLE
Fix wrong SafeTestsets UUID in test extras (unbreaks master CI)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-SafeTestsets = "1201f925-eb70-4ca8-ba2c-9b673ab8e7da"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 PolyChaos = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
-SafeTestsets = "1201f925-eb70-4ca8-ba2c-9b673ab8e7da"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 


### PR DESCRIPTION
## Problem

All master CI jobs (Core, QA on `1`/`lts`, and Downgrade) are red. They all fail at **test-dependency resolution**, before any test code runs:

```
expected package `SafeTestsets [1201f925]` to be registered
 You may have provided the wrong UUID for package SafeTestsets.
 Found the following UUIDs for that name:
  - 1bc83da4-3b8d-516f-aca4-4fe02f6d838f from registry: General
```

The SciMLTesting v1.2 folder conversion (#163) added `SafeTestsets` to the test extras with an **invalid UUID** `1201f925-eb70-4ca8-ba2c-9b673ab8e7da`, which matches no registered package. The Downgrade job hits the same error when it merges the project's `SafeTestsets` extra into the resolver.

## Fix

Correct the UUID to the registered `SafeTestsets` UUID `1bc83da4-3b8d-516f-aca4-4fe02f6d838f` (verified against the live General registry) in both places it appears:

- `Project.toml` `[extras]`
- `test/qa/Project.toml` `[deps]`

`SciMLTesting`'s UUID in the same files was already correct.

## Local verification (Julia 1.10, the `[compat]` floor)

- **QA group**: `QA/qa.jl | Pass 10 / Total 10` — `Testing PolyChaos tests passed`. (Aqua's `test_project_extras` now passes, which would otherwise also flag the bad UUID.)
- **Core group**: all files green (`polynomial_chaos` 5175/5175, `recurrence_coefficients` 10510/10510, `types` 3427/3427, etc.) — `Testing PolyChaos tests passed`, exit 0.

Two-line metadata change; no Julia source touched, so Runic is not applicable.

Please ignore until reviewed by @ChrisRackauckas.
