### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,14 +17,13 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AdaptiveRejectionSampling = "0.1, 0.2"
-Aqua = "0.8"
 Combinatorics = "1.0"
 Distributions = "0.25"
 FFTW = "1.2"
 GaussQuadrature = "0.5"
 LinearAlgebra = "1"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 SparseArrays = "1"
 Test = "1"
 QuadGK = "2.4"
@@ -34,11 +33,10 @@ Statistics = "1"
 julia = "1.10"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "SafeTestsets", "SciMLTesting", "StaticArrays", "Test"]
+test = ["SafeTestsets", "SciMLTesting", "StaticArrays", "Test"]

--- a/src/PolyChaos.jl
+++ b/src/PolyChaos.jl
@@ -2,8 +2,11 @@ __precompile__()
 
 module PolyChaos
 
-    using SpecialFunctions, SparseArrays, Distributions
-    import LinearAlgebra: I, dot, SymTridiagonal, eigen, issymmetric, pinv
+    using SpecialFunctions: beta, gamma
+    using SparseArrays: SparseVector, spzeros
+    using Distributions: Beta, Continuous, Distribution, Gamma, Logistic, Normal,
+        Uniform, Univariate
+    import LinearAlgebra: I, dot, issymmetric
     import FFTW: ifft
     import Combinatorics: with_replacement_combinations
     import Base: show

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,14 +1,12 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 PolyChaos = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,10 +1,6 @@
-using PolyChaos, Aqua, Test
+using SciMLTesting, PolyChaos, Test
 
-Aqua.find_persistent_tasks_deps(PolyChaos)
-Aqua.test_ambiguities(PolyChaos, recursive = false)
-Aqua.test_deps_compat(PolyChaos)
-Aqua.test_piracies(PolyChaos)
-Aqua.test_project_extras(PolyChaos)
-Aqua.test_stale_deps(PolyChaos)
-Aqua.test_unbound_args(PolyChaos)
-Aqua.test_undefined_exports(PolyChaos)
+run_qa(
+    PolyChaos; explicit_imports = true,
+    aqua_kwargs = (; ambiguities = (; recursive = false))
+)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the hand-rolled `test/qa/qa.jl` (eight individual `Aqua.test_*` calls) to SciMLTesting 1.6.0's `run_qa`, with **ExplicitImports enabled** (`explicit_imports = true`).

## qa.jl

```julia
using SciMLTesting, PolyChaos, Test

run_qa(
    PolyChaos; explicit_imports = true,
    aqua_kwargs = (; ambiguities = (; recursive = false))
)
```

- The eight `Aqua.test_*` calls collapse into `Aqua.test_all` via `run_qa`.
- The prior `test_ambiguities(PolyChaos, recursive = false)` tweak is preserved via `aqua_kwargs = (; ambiguities = (; recursive = false))`.
- No JET (the prior QA did not run JET).

## ExplicitImports findings — all FIXED in src (0 ignore, 0 broken)

- **`no_stale_explicit_imports`**: dropped unused `LinearAlgebra` imports `SymTridiagonal`, `eigen`, `pinv` (verified unused in `src/`; not exported, not method-extension placeholders). Kept `I`, `dot`, `issymmetric` (used).
- **`no_implicit_imports`**: made the implicit `using SpecialFunctions, SparseArrays, Distributions` explicit:
  ```julia
  using SpecialFunctions: beta, gamma
  using SparseArrays: SparseVector, spzeros
  using Distributions: Beta, Continuous, Distribution, Gamma, Logistic, Normal,
                       Uniform, Univariate
  ```
- `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`, `all_qualified_accesses_are_public`, `all_explicit_imports_are_public`: already passing.

## Deps

- `test/qa/Project.toml`: `SciMLTesting` compat -> `"1.6"`; dropped `SafeTestsets` (unused by `qa.jl`; the harness provides `@safetestset` at the `runtests` level); `Aqua` kept (the ambiguities sub-check spawns a child process that needs `Aqua` as a direct dep). `ExplicitImports` not added (transitive via SciMLTesting).
- Root `Project.toml`: dropped `Aqua` from `[compat]`/`[extras]`/`[targets].test` (now exclusively a QA sub-env dep since QA runs in its own folder env); bumped `SciMLTesting` compat to `"1.6"`.

## Verification (local, released SciMLTesting 1.6.0, Julia 1.12.5)

QA group: **17/17 Pass, 0 Fail/Error/Broken** (11 Aqua sub-checks + 6 ExplicitImports checks). All six EI checks confirmed passing individually.

> Note: a separate pre-existing flaky Core test (`test/polynomial_chaos.jl:40`, "Mean and variance of beta distribution") can intermittently miss its `atol = 1e-2` Monte-Carlo tolerance. Stress-tested on both clean `master` and this branch (~22k sampling checks each): identical behavior, maxdiff ~0.009 right at the tolerance edge. It is unrelated to this change (the explicit-import refactor produces bit-identical function bindings) and is **not** touched here; it is a master-level flake driven by unseeded randomized test inputs (`α = rand():2:10`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)