### PR TITLE
Release prep: bump PolyChaos to 1.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolyChaos"
 uuid = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 authors = ["Tillmann Mühlpfordt <tillmann.muehlpfordt@kit.edu>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 AdaptiveRejectionSampling = "c75e803d-635f-53bd-ab7d-544e482d8c75"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes on master since the 1.2.1 registration (no functional/API changes).