### PR TITLE
Drop StaticArrays 0.12 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Test = "1"
 QuadGK = "2.4"
 Random = "1"
 SpecialFunctions = "1, 2"
-StaticArrays = "0.12, 1.0"
+StaticArrays = "1"
 Statistics = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary

- remove the obsolete StaticArrays 0.12 test compatibility line
- require StaticArrays 1 for PolyChaos's static-array test coverage

StaticArrays 1.0 was released in 2020, and PolyChaos already exercises the relevant static vector and matrix cases against that API. This only changes a test dependency compatibility bound; package runtime dependencies and public API are unchanged.

## Local validation

- locked test environment with `StaticArrays v1.0.0`: all 16 Core files passed (20,522 tests)
- current test environment with `StaticArrays v1.9.18`: all 16 Core files passed (20,522 tests)
- `GROUP=QA julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=../../runic_env -e 'using Runic; exit(Runic.main(["--check", "."]))'`

The stochastic inverse-transform sampling assertion has a separately reproduced clean-`master` seed-dependent failure. This PR does not alter or suppress that test; its root cause is being investigated independently.

Ignore this PR until it has been reviewed by @ChrisRackauckas.
