### PR TITLE
Fix inverse CDF tail refinement and Gamma regression

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -38,6 +38,14 @@ function sampleInverseCDF(n::Int, pdf::Function, dom::Tuple{<:Real, <:Real})
     n < 1 && throw(DomainError(n, "Number of samples must be positive"))
     !(dom[1] < dom[2]) && throw(DomainError(dom, "Invalid domain bounds"))
 
+    return _sample_inverse_cdf(n, pdf, dom)
+end
+
+function _sample_inverse_cdf(
+        draws::Union{Int, AbstractVector{<:Real}}, pdf::Function,
+        dom::Tuple{<:Real, <:Real}
+    )
+
     # Handle infinite domains by truncating
     a, b = _handle_domain(dom)
 
@@ -60,15 +68,19 @@ function sampleInverseCDF(n::Int, pdf::Function, dom::Tuple{<:Real, <:Real})
     v = _simple_chebpolyval(cdf_coeffs)
     tol = 100 * eps()
 
-    idx1 = something(findfirst(v_ -> v_ > tol, v), 1)
-    idx2 = something(findlast(v_ -> v_ < 1 - tol, v), length(v))
+    first_above_lower = something(findfirst(v_ -> v_ > tol, v), 1)
+    last_below_upper = something(findlast(v_ -> v_ < 1 - tol, v), length(v))
+
+    # Keep the nodes bracketing the cutoffs so resolved tail mass is not discarded.
+    lower_idx = max(first_above_lower - 1, 1)
+    upper_idx = min(last_below_upper + 1, length(v))
 
     k = length(v) - 1
     chebnodes = sin.(π * (-k:2:k) / (2k))
 
     # Refined domain
-    dnew_a = (b - a) * (chebnodes[idx1] + 1) / 2 + a
-    dnew_b = (b - a) * (chebnodes[idx2] + 1) / 2 + a
+    dnew_a = (b - a) * (chebnodes[lower_idx] + 1) / 2 + a
+    dnew_b = (b - a) * (chebnodes[upper_idx] + 1) / 2 + a
 
     # Reconstruct on refined domain
     map_fn_new(t) = (dnew_b - dnew_a) * (t + 1) / 2 + dnew_a
@@ -82,7 +94,8 @@ function sampleInverseCDF(n::Int, pdf::Function, dom::Tuple{<:Real, <:Real})
     Y_new = Y_new ./ integral_new
 
     # Generate samples and map back
-    samples_canonical = _generate_random_samples(Y_new, n)
+    probabilities = draws isa Int ? rand(draws) : draws
+    samples_canonical = _invert_cdf(Y_new, probabilities)
     samples = map_fn_new.(samples_canonical)
 
     return samples
@@ -108,24 +121,22 @@ function _handle_domain(dom::Tuple{<:Real, <:Real})
 end
 
 """
-Generate random samples using inverse CDF via bisection.
+Invert the CDF at the supplied probabilities via bisection.
 """
-function _generate_random_samples(Y::Vector{Float64}, n::Int)
+function _invert_cdf(Y::Vector{Float64}, probabilities::AbstractVector{<:Real})
     # Compute CDF coefficients
     cdf = _simple_cumsum(Y)
 
-    # Generate uniform random samples
-    r = rand(n)
-
     # Bisection method
+    n = length(probabilities)
     a = -ones(n)
     b = ones(n)
 
     while norm(b - a, Inf) > eps()
         mid = (a + b) / 2
         vals = _clenshaw_evaluate(cdf, mid)
-        I1 = (vals .- r) .<= -eps()
-        I2 = (vals .- r) .>= eps()
+        I1 = (vals .- probabilities) .<= -eps()
+        I2 = (vals .- probabilities) .>= eps()
         I3 = .~I1 .& .~I2
         a = I1 .* mid .+ I2 .* a .+ I3 .* mid
         b = I1 .* b .+ I2 .* mid .+ I3 .* mid

--- a/test/inverse_transform_sampling.jl
+++ b/test/inverse_transform_sampling.jl
@@ -1,3 +1,4 @@
+using Distributions: Gamma, cdf
 using PolyChaos, Test
 
 @testset "Inverse Transform Sampling" begin
@@ -53,8 +54,15 @@ using PolyChaos, Test
 
         # GammaMeasure (semi-infinite domain)
         m = GammaMeasure(2.0, 1.0)
-        samples = sampleMeasure(Nsamples, m; method = "inversecdf")
-        @test isapprox(mean(samples), 2.0; atol = atol_mean)
+        probabilities = collect(range(0.001, 0.999; length = 999))
+        samples = PolyChaos._sample_inverse_cdf(probabilities, m.w, m.dom)
+        reference = Gamma(2.0, 1.0)
+        lower, upper = PolyChaos._handle_domain(m.dom)
+        reference_lower = cdf(reference, lower)
+        reference_mass = cdf(reference, upper) - reference_lower
+        sample_probabilities =
+            (cdf.(Ref(reference), samples) .- reference_lower) ./ reference_mass
+        @test sample_probabilities ≈ probabilities
     end
 
     @testset "OrthoPoly interface with inversecdf" begin


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- retain the Chebyshev nodes that bracket each CDF tail cutoff, instead of selecting the first nodes inside the retained mass
- preserve the existing public sampling API while allowing the package's internal inverse-CDF path to consume an explicit probability grid
- replace the flaky Gamma sample-mean assertion with a deterministic conditional-CDF identity against Distributions.jl

## Root cause

The statistical failure and the numerical defect were related but distinct.

For `Gamma(2, 1)` with 5,000 samples, the sample-mean standard error is `sqrt(2 / 5000) = 0.02`. A 200-seed scan produced an empirical standard deviation of `0.02159`, and 4/200 means exceeded the test's fixed `atol = 0.05`. For example, seed 21 gives `1.9366639977`, so the existing assertion can fail under ordinary Monte Carlo variation.

The deterministic CDF comparison also exposed a real refinement bug. The old lower boundary was `0.0547810463`, which discards `0.00144679235` of the reference Gamma mass. The code selected the first Chebyshev node whose CDF was above the cutoff, rather than the preceding node that brackets it. The same off-by-one direction was present at the upper cutoff.

After retaining the bracketing nodes, the explicit 999-point conditional-CDF grid has a maximum error of `1.67e-14` with no custom tolerance.

An isolated `git bisect run` identified `b059b431e821bfdc57ceb9d69d5db3233abb6f81` (`Add inverse transform sampling using Chebyshev technology`) as the first commit containing the failing behavior and assertion.

## Investigation workflow

1. Reproduced the stochastic failure on untouched `upstream/master` at `2f6205d`.
2. Checked the explicit seed-22 stream across Julia 1.10.0, 1.10.8, 1.10.10, 1.10.11, 1.11.9, and 1.12.6; all produced the same passing mean `1.9784477486`. The previously recorded `2.052681` result therefore depended on different ambient RNG consumption, not a Julia patch-level RNG boundary.
3. Quantified mean variance at 1,000, 5,000, and 20,000 samples and compared it with the theoretical standard error.
4. Compared generated samples to the documented public `Distributions.Gamma` and `cdf` APIs, which revealed the dropped lower-tail mass.
5. Added the deterministic probability-grid regression first and observed the focused suite fail 15/16 before applying the boundary fix.
6. Applied the bracketing fix and reran focused, compatibility, Core, QA, and formatting checks.

## Verification

- deterministic regression before fix: **15 passed, 1 failed**
- focused inverse-transform suite after fix: **16/16**
- focused suite repeated 10 times: **160/160**
- SpecialFunctions 1.8.8 compatibility graph: **16/16**
- current SpecialFunctions 2.8.0 graph: **16/16**
- `GROUP=Core Pkg.test()`: **20,522/20,522**
- `GROUP=QA Pkg.test()`: **17/17**
- Runic check across all 43 Julia files: **43/43**
