### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,5 @@ using SciMLTesting, PolyChaos, Test
 
 run_qa(
     PolyChaos; explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; ambiguities = (; recursive = false))
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,6 @@
 using SciMLTesting, PolyChaos, Test
 
 run_qa(
-    PolyChaos; explicit_imports = true,
+    PolyChaos;
     aqua_kwargs = (; ambiguities = (; recursive = false))
 )


### PR DESCRIPTION
Removes the redundant rendered-docs override now that SciMLTesting 2.3 enables strict public API rendering by default.

Ignore until reviewed by @ChrisRackauckas.