### PR TITLE
Drop AdaptiveRejectionSampling to unblock ForwardDiff 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "PolyChaos"
 uuid = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 authors = ["Tillmann Mühlpfordt <tillmann.muehlpfordt@kit.edu>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
-AdaptiveRejectionSampling = "c75e803d-635f-53bd-ab7d-544e482d8c75"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -17,7 +16,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-AdaptiveRejectionSampling = "0.1, 0.2"
 Combinatorics = "1.0"
 Distributions = "0.25"
 FFTW = "1.2"

--- a/src/PolyChaos.jl
+++ b/src/PolyChaos.jl
@@ -18,7 +18,6 @@ module PolyChaos
     import FFTW: ifft
     import Combinatorics: with_replacement_combinations
     import Base: show
-    import AdaptiveRejectionSampling: RejectionSampler, run_sampler!
     import Statistics
     import GaussQuadrature: special_eigenproblem!
 

--- a/src/polynomial_chaos.jl
+++ b/src/polynomial_chaos.jl
@@ -170,9 +170,9 @@ end
 __Univariate__
 
 ```
-sampleMeasure(n::Int,name::String,w::Function,dom::Tuple{<:Real,<:Real},symm::Bool,d::Dict;method::String="adaptiverejection")
-sampleMeasure(n::Int,m::Measure;method::String="adaptiverejection")
-sampleMeasure(n::Int,op::AbstractOrthoPoly;method::String="adaptiverejection")
+sampleMeasure(n::Int,name::String,w::Function,dom::Tuple{<:Real,<:Real},symm::Bool,d::Dict;method::String="inversecdf")
+sampleMeasure(n::Int,m::Measure;method::String="inversecdf")
+sampleMeasure(n::Int,op::AbstractOrthoPoly;method::String="inversecdf")
 ```
 
 Draw `n` samples from the measure `m` described by its
@@ -182,8 +182,10 @@ Draw `n` samples from the measure `m` described by its
   - domain `dom`,
   - symmetry property `symm`,
   - and, if applicable, parameters stored in the dictionary `d`.
-    By default, an adaptive rejection sampling method is used (from [AdaptiveRejectionSampling.jl](https://github.com/JuliaStats/AdaptiveRejectionSampling.jl)),
-    unless it is a common random variable for which [Distributions.jl](https://github.com/JuliaStats/Distributions.jl) is used.
+    Generic measures are sampled by inverse transform sampling
+    (`method = "inversecdf"`; see [`sampleInverseCDF`](@ref)). Canonical
+    measures are sampled from [Distributions.jl](https://github.com/JuliaStats/Distributions.jl)
+    unless `method = "inversecdf"` is requested.
 
 The function is dispatched to accept `AbstractOrthoPoly`.
 
@@ -199,31 +201,31 @@ as many columns as the multimeasure has univariate measures.
 """
 function sampleMeasure(
         n::Int, w::Function, dom::Tuple{<:Real, <:Real};
-        method::String = "adaptiverejection"
+        method::String = "inversecdf"
     )
     _checkNumberOfSamples(n)
     method = lowercase(method)
 
     if method == "adaptiverejection"
-        # works only if w is log-concave
-        sampler = RejectionSampler(w, dom)
-        return run_sampler!(sampler, n)
+        Base.depwarn(
+            "method=\"adaptiverejection\" is deprecated; use method=\"inversecdf\"",
+            :sampleMeasure
+        )
+        return sampleInverseCDF(n, w, dom)
     elseif method == "rejection"
-        # all purpose method but needs a solid envelope PDF
         throw(error("method $method not yet implemented"))
     elseif method == "inversecdf"
-        # Inverse transform sampling using Chebyshev technology
         return sampleInverseCDF(n, w, dom)
     else
         throw(error("method $method not implemented"))
     end
 end
 
-function sampleMeasure(n::Int, meas::AbstractMeasure; method::String = "adaptiverejection")
+function sampleMeasure(n::Int, meas::AbstractMeasure; method::String = "inversecdf")
     return sampleMeasure(n, meas.w, meas.dom; method = method)
 end
 
-function sampleMeasure(n::Int, op::AbstractOrthoPoly; method::String = "adaptiverejection")
+function sampleMeasure(n::Int, op::AbstractOrthoPoly; method::String = "inversecdf")
     return sampleMeasure(n, op.measure; method = method)
 end
 function sampleMeasure(n::Int, op::AbstractCanonicalOrthoPoly)
@@ -352,7 +354,7 @@ end
 __Univariate__
 
 ```
-samplePCE(n::Int,x::AbstractVector{<:Real},op::AbstractOrthoPoly;method::String="adaptiverejection")
+samplePCE(n::Int,x::AbstractVector{<:Real},op::AbstractOrthoPoly;method::String="inversecdf")
 ```
 
 Combines [`sampleMeasure`](@ref) and [`evaluatePCE`](@ref), i.e. it first draws `n` samples
@@ -366,7 +368,7 @@ samplePCE(n::Int,x::AbstractVector{<:Real},mop::MultiOrthoPoly;method::Vector{St
 """
 function samplePCE(
         n::Int, x::AbstractVector{<:Real}, op::AbstractOrthoPoly;
-        method::String = "adaptiverejection"
+        method::String = "inversecdf"
     )
     ξ = sampleMeasure(n, op; method = method)
     return evaluatePCE(x, ξ, op)

--- a/test/inverse_transform_sampling.jl
+++ b/test/inverse_transform_sampling.jl
@@ -30,6 +30,8 @@ using PolyChaos, Test
         # Custom Measure
         w = x -> exp(-x^2)
         m = Measure("custom_gaussian", w, (-5.0, 5.0), true)
+        samples = sampleMeasure(Nsamples, m)
+        @test isapprox(mean(samples), 0.0; atol = atol_mean)
         samples = sampleMeasure(Nsamples, m; method = "inversecdf")
         @test isapprox(mean(samples), 0.0; atol = atol_mean)
 
@@ -78,5 +80,12 @@ using PolyChaos, Test
         @test_throws DomainError sampleInverseCDF(0, pdf, (0.0, 1.0))
         @test_throws DomainError sampleInverseCDF(-1, pdf, (0.0, 1.0))
         @test_throws DomainError sampleInverseCDF(10, pdf, (1.0, 0.0))
+    end
+
+    @testset "deprecated adaptiverejection method" begin
+        w = x -> exp(-x^2)
+        m = Measure("custom_gaussian", w, (-5.0, 5.0), true)
+        samples = @test_deprecated sampleMeasure(10, m; method = "adaptiverejection")
+        @test length(samples) == 10
     end
 end


### PR DESCRIPTION
Drop AdaptiveRejectionSampling. It is the only reason SciML packages that use PolyChaos cannot resolve ForwardDiff 1.

## Why

Registered AdaptiveRejectionSampling 0.1.0–0.2.1 has Compat `[0] ForwardDiff = "0.10.1-0.10"`. Downstream extras graphs that include both PolyChaos and ForwardDiff 1 (e.g. SciML/Surrogates.jl tests) are unsatisfiable:

```
PolyChaos 2.0.0/2.1.0 requires AdaptiveRejectionSampling
AdaptiveRejectionSampling 0.1.0–0.2.1 requires ForwardDiff at 0.10
compat leaves ForwardDiff at ≥ 1.0.0
```

ARS is not needed for the public orthogonal-polynomial / PCE API. Canonical measures already sample from Distributions.jl. Generic measures already have inverse transform sampling (`sampleInverseCDF`). Tests never called the ARS path.

Unreleased AdaptiveRejectionSampling.jl `master` has a different API (`ARSampler`/`sample!`) and is not registered; we cannot depend on it.

## What changed

- Remove AdaptiveRejectionSampling from `[deps]` / `[compat]`.
- Generic `sampleMeasure` / `samplePCE` default to `method="inversecdf"`.
- `method="adaptiverejection"` depwarns and uses inversecdf.
- Bump 2.1.0 → 2.2.0.

Canonical `sampleMeasure` still uses Distributions.jl. Multivariate defaults still pass `"adaptiverejection"` into the canonical method, which ignores it and samples from Distributions.jl (pre-existing warning).

## Verification

Julia 1.10.11, `Pkg.test(; allow_reresolve=false)`:

- Core: passed (`inverse_transform_sampling.jl` 19; `polynomial_chaos.jl` 4950; `recurrence_coefficients.jl` 10510; `types.jl` 3427; full suite green, ~5.5 min).
- QA (`GROUP=QA`): 18 passed in 28s.

Resolver.jl `--min=@deps` on a Surrogates extras-promoted Project.toml (ForwardDiff = `"1"`, PolyChaos extra):

- Current General: unsatisfiable (ARS pins ForwardDiff 0.10).
- Same graph plus a local overlay of PolyChaos 2.2.0 without ARS: PolyChaos 2.2.0 + ForwardDiff 1.0.1.

Docs `make.jl` failed on pre-existing `docs/src/multiple_discretization.md` `@setup` (`Float64 / Vector{Float64}`), not on `sampleMeasure` / ARS. Not changed here.

Not verified: GPU, downstream packages other than local Surrogates (running separately).

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)