### PR TITLE
Format for Runic v1.10

### DIFF
--- a/test/scalarproducts.jl
+++ b/test/scalarproducts.jl
@@ -19,9 +19,9 @@ tol = 1.0e-7
         s = computeSP2(opq)
         t = [
             quadgk(
-                    x -> evaluate(d, x, opq)^2 * opq.measure.w(x), opq.measure.dom...;
-                    order = max(10, 10d)
-                )[1]
+                x -> evaluate(d, x, opq)^2 * opq.measure.w(x), opq.measure.dom...;
+                order = max(10, 10d)
+            )[1]
                 for d in 0:deg
         ]
         u = computeSP2(deg, opq)
@@ -59,9 +59,9 @@ names = [Beta01OrthoPoly, JacobiOrthoPoly, genHermiteOrthoPoly]
         s = computeSP2(opq)
         t = [
             quadgk(
-                    x -> evaluate(d, x, opq)^2 * opq.measure.w(x), opq.measure.dom...;
-                    order = max(10, 10d)
-                )[1]
+                x -> evaluate(d, x, opq)^2 * opq.measure.w(x), opq.measure.dom...;
+                order = max(10, 10d)
+            )[1]
                 for d in 0:deg
         ]
         u = computeSP2(deg, opq)


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `a7c52a41106a`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos test/scalarproducts.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA 20/20 passed; package tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Final Core files show 11/11 and 3427/3427 passed; package tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)