### PR TITLE
Release PolyChaos 2.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolyChaos"
 uuid = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 authors = ["Tillmann Mühlpfordt <tillmann.muehlpfordt@kit.edu>"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 AdaptiveRejectionSampling = "c75e803d-635f-53bd-ab7d-544e482d8c75"


### PR DESCRIPTION
Bumps `PolyChaos` 2.1.0 -> 2.1.1 (patch).

Source files changed since 2.1.0:
- `src/densities.jl`
- `src/evaluate.jl`
- `src/multi_indices.jl`
- `src/polynomial_chaos.jl`
- `src/quadrature_rules.jl`
- `src/recurrence_coefficients_monic.jl`
- `src/show.jl`
- `src/stieltjes.jl`

Commits:
- Format for Runic v1.10 (#188)
- docs: render all public PolyChaos API (#182)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
