### PR TITLE
Fix numberPolynomials MethodError on 32-bit Julia

### DIFF
--- a/src/auxfuns.jl
+++ b/src/auxfuns.jl
@@ -244,7 +244,7 @@ Convert scalar-product basis indices to coordinate-wise univariate indices.
 
 A matrix whose column `j` is the univariate multi-index represented by `a[j]`.
 """
-function multi2uni(a::AbstractVector{<:Int}, ind::AbstractMatrix{<:Int})
+function multi2uni(a::AbstractVector{<:Integer}, ind::AbstractMatrix{<:Integer})
     minimum(a) < 0 && throw(DomainError(a, "no negative degrees allowed"))
     l, p = size(ind) # p-variate basis
     m = length(a) # dimension of scalar product
@@ -255,7 +255,7 @@ function multi2uni(a::AbstractVector{<:Int}, ind::AbstractMatrix{<:Int})
             "not enough elements in multi-index (requested: $(maximum(a)), max: $l)"
         )
     )
-    A = zeros(Int64, p, m)
+    A = zeros(Int, p, m)
     for (i, a_element) in enumerate(a)
         A[:, i] = ind[a_element + 1, :]
     end
@@ -277,8 +277,8 @@ Return a sparse scalar-product tensor entry.
 `a` is sorted in place in descending order before lookup.
 """
 function getentry(
-        a::AbstractVector{<:Int}, T::SparseVector{<:Real, <:Int},
-        ind::AbstractMatrix{<:Int}, dim::Int
+        a::AbstractVector{<:Integer}, T::SparseVector{<:Real, <:Int},
+        ind::AbstractMatrix{<:Integer}, dim::Int
     )
     m = length(a)
     l = size(ind, 1) - 1

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -39,7 +39,7 @@ julia> evaluate(1, 0.5, LegendreOrthoPoly(2))
 ```
 """
 function evaluate(
-        n::Int, x::AbstractArray{<:Real}, a::AbstractVector{<:Real},
+        n::Integer, x::AbstractArray{<:Real}, a::AbstractVector{<:Real},
         b::AbstractVector{<:Real}
     )
     @assert n >= 0 "Degree n has to be non-negative (currently n=$n)."
@@ -64,13 +64,13 @@ function evaluate(
     end
     return nx == 1 ? first(pplus) : pplus
 end
-function evaluate(n::Int, x::Real, a::AbstractVector{<:Real}, b::AbstractVector{<:Real})
+function evaluate(n::Integer, x::Real, a::AbstractVector{<:Real}, b::AbstractVector{<:Real})
     return evaluate(n, [x], a, b)
 end
-function evaluate(n::Int, x::AbstractVector{<:Real}, op::AbstractOrthoPoly)
+function evaluate(n::Integer, x::AbstractVector{<:Real}, op::AbstractOrthoPoly)
     return evaluate(n, x, op.α, op.β)
 end
-evaluate(n::Int, x::Real, op::AbstractOrthoPoly) = evaluate(n, [x], op)
+evaluate(n::Integer, x::Real, op::AbstractOrthoPoly) = evaluate(n, [x], op)
 
 # univariate + several bases
 function evaluate(
@@ -92,7 +92,7 @@ evaluate(x::Real, op::AbstractOrthoPoly) = evaluate([x], op)
 
 # multivariate
 function evaluate(
-        n::AbstractVector{<:Int}, x::AbstractMatrix{<:Real},
+        n::AbstractVector{<:Integer}, x::AbstractMatrix{<:Real},
         a::AbstractVector{<:AbstractVector{<:Real}},
         b::AbstractVector{<:AbstractVector{<:Real}}
     )
@@ -104,22 +104,22 @@ function evaluate(
     return val
 end
 function evaluate(
-        n::AbstractVector{<:Int}, x::AbstractVector{<:Real},
+        n::AbstractVector{<:Integer}, x::AbstractVector{<:Real},
         a::AbstractVector{<:AbstractVector{<:Real}},
         b::AbstractVector{<:AbstractVector{<:Real}}
     )
     return evaluate(n, reshape(x, 1, length(x)), a, b)
 end
-function evaluate(n::AbstractVector{<:Int}, x::AbstractMatrix{<:Real}, op::MultiOrthoPoly)
+function evaluate(n::AbstractVector{<:Integer}, x::AbstractMatrix{<:Real}, op::MultiOrthoPoly)
     return evaluate(n, x, coeffs(op)...)
 end
-function evaluate(n::AbstractVector{<:Int}, x::AbstractVector{<:Real}, op::MultiOrthoPoly)
+function evaluate(n::AbstractVector{<:Integer}, x::AbstractVector{<:Real}, op::MultiOrthoPoly)
     return evaluate(n, reshape(x, 1, length(x)), op)
 end
 
 # using multi-index + multivariate
 function evaluate(
-        ind::AbstractMatrix{<:Int}, x::AbstractMatrix{<:Real},
+        ind::AbstractMatrix{<:Integer}, x::AbstractMatrix{<:Real},
         a::AbstractVector{<:AbstractVector{<:Real}},
         b::AbstractVector{<:AbstractVector{<:Real}}
     )
@@ -127,19 +127,19 @@ function evaluate(
     return hcat(vals...) |> transpose |> Matrix
 end
 
-function evaluate(ind::AbstractMatrix{<:Int}, x::AbstractMatrix{<:Real}, op::MultiOrthoPoly)
+function evaluate(ind::AbstractMatrix{<:Integer}, x::AbstractMatrix{<:Real}, op::MultiOrthoPoly)
     return evaluate(ind, x, coeffs(op)...)
 end
 evaluate(x::AbstractMatrix{<:Real}, mop::MultiOrthoPoly) = evaluate(mop.ind, x, mop)
 
 function evaluate(
-        ind::AbstractMatrix{<:Int}, x::AbstractVector{<:Real},
+        ind::AbstractMatrix{<:Integer}, x::AbstractVector{<:Real},
         a::AbstractVector{<:AbstractVector{<:Real}},
         b::AbstractVector{<:AbstractVector{<:Real}}
     )
     return evaluate(ind, reshape(x, 1, length(x)), a, b)
 end
-function evaluate(ind::AbstractMatrix{<:Int}, x::AbstractVector{<:Real}, op::MultiOrthoPoly)
+function evaluate(ind::AbstractMatrix{<:Integer}, x::AbstractVector{<:Real}, op::MultiOrthoPoly)
     return evaluate(ind, reshape(x, 1, length(x)), coeffs(op)...)
 end
 function evaluate(x::AbstractVector{<:Real}, mop::MultiOrthoPoly)

--- a/src/multi_indices.jl
+++ b/src/multi_indices.jl
@@ -68,7 +68,7 @@ end
     `(d+n)!/(d!+n!)`
 """
 
-function numberPolynomials(d::Int64, n::Int64)
+function numberPolynomials(d::Integer, n::Integer)
     x, y = max(d, n), min(d, n)
     return UInt128(prod(UInt128(x + 1):UInt128(d + n)) ÷ factorial(UInt128(y)))
 end

--- a/src/multi_indices.jl
+++ b/src/multi_indices.jl
@@ -26,7 +26,7 @@ julia> size(calculateMultiIndices(2, 2))
 (6, 2)
 ```
 """
-function calculateMultiIndices(d::Int, n::Int)
+function calculateMultiIndices(d::Integer, n::Integer)
     # d denotes dimension of random variables/number of sources of uncertainty,
     # n the maximum degree of multivariate basis
     # function to calculate indices of multivariate basis following the algorithm
@@ -35,11 +35,11 @@ function calculateMultiIndices(d::Int, n::Int)
     n < 0 && throw(DomainError(n, "maximum degree must be non-negative"))
     d <= 0 && throw(DomainError(d, "number of uncertainties must be positive"))
     # catch case n == 0 --> No-d==0
-    n == 0 && return zeros(Int64, 1, d)
+    n == 0 && return zeros(Int, 1, d)
     # non-pathological cases begin here
     No = numberPolynomials(d, n)
-    inds = vcat(zeros(Int64, 1, d), Matrix(1I, d, d), zeros(Int64, No - d - 1, d))  #initiate index matrix for basis
-    pi = ones(Int64, No, d)
+    inds = vcat(zeros(Int, 1, d), Matrix(1I, d, d), zeros(Int, No - d - 1, d))  #initiate index matrix for basis
+    pi = ones(Int, No, d)
 
     for k in 2:No
         g = 0
@@ -95,7 +95,7 @@ function findUnivariateIndices(i::Int, ind::AbstractMatrix{Int})
     deg = ind[end, end]
     deg < 0 && throw(DomainError(deg, "invalid degree"))
     col = ind[:, i]
-    myind = zeros(Int64, deg)
+    myind = zeros(Int, deg)
     for deg_ in 1:deg
         myind[deg_] = findfirst(x -> x == deg_, col)
     end

--- a/src/polynomial_chaos.jl
+++ b/src/polynomial_chaos.jl
@@ -490,7 +490,7 @@ mean(x::AbstractVector, op::AbstractOrthoPoly) = x[1] * computeSP2(0, op.β)
 
 function mean(x::AbstractVector, mop::MultiOrthoPoly)
     nunc = length(mop.uni)
-    return x[1] * computeSP(zeros(Int64, nunc), mop)
+    return x[1] * computeSP(zeros(Int, nunc), mop)
 end
 
 """

--- a/src/quadrature_rules.jl
+++ b/src/quadrature_rules.jl
@@ -7,7 +7,7 @@ export fejer,
     radau,
     lobatto
 """
-    fejer(N::Int)
+    fejer(N::Integer)
 
 Fejer's first quadrature rule on `(-1, 1)`.
 
@@ -19,7 +19,7 @@ Fejer's first quadrature rule on `(-1, 1)`.
 
 A pair `(nodes, weights)` containing `N` nodes and weights.
 """
-function fejer(N::Int)
+function fejer(N::Integer)
     @assert N >= 1 "N has to be positive"
     N == 1 && return zeros(1), [2.0]
     θ = map(x -> (2x - 1) * pi / (2N), 1:N)
@@ -29,7 +29,7 @@ function fejer(N::Int)
 end
 
 """
-    fejer2(n::Int)
+    fejer2(n::Integer)
 
 Fejer's second quadrature rule according to [Waldvogel, J. Bit Numer Math (2006) 46: 195](https://doi.org/10.1007/s10543-006-0045-4).
 
@@ -41,7 +41,7 @@ Fejer's second quadrature rule according to [Waldvogel, J. Bit Numer Math (2006)
 
 A pair `(nodes, weights)` containing `n + 1` nodes and weights.
 """
-function fejer2(n::Int)
+function fejer2(n::Integer)
     @assert n >= 2
     N = 1:2:(n - 1)
     m = n - length(N)
@@ -52,7 +52,7 @@ function fejer2(n::Int)
 end
 
 """
-    clenshaw_curtis(n::Int)
+    clenshaw_curtis(n::Integer)
 
 Clenshaw-Curtis quadrature according to [Waldvogel, J. Bit Numer Math (2006) 46: 195](https://doi.org/10.1007/s10543-006-0045-4).
 
@@ -64,7 +64,7 @@ Clenshaw-Curtis quadrature according to [Waldvogel, J. Bit Numer Math (2006) 46:
 
 A pair `(nodes, weights)` containing `n + 1` nodes and weights on `(-1, 1)`.
 """
-function clenshaw_curtis(n::Int)
+function clenshaw_curtis(n::Integer)
     @assert n >= 2
     N = 1:2:(n - 1)
     l = length(N)
@@ -80,7 +80,7 @@ function clenshaw_curtis(n::Int)
 end
 
 """
-    quadgp(weight::Function,lb::Real,ub::Real,N::Int=10;quadrature::Function=clenshaw_curtis,bnd::Float64=Inf)
+    quadgp(weight::Function,lb::Real,ub::Real,N::Integer=10;quadrature::Function=clenshaw_curtis,bnd::Float64=Inf)
 
 general purpose quadrature based on Gautschi, "Orthogonal Polynomials: Computation and Approximation", Section 2.2.2, pp. 93-95
 
@@ -105,7 +105,7 @@ The keyword `bnd` sets the numerical value for infinity.
 A pair `(nodes, weights)` for the requested support.
 """
 function quadgp(
-        weight::Function, lb::Real, ub::Real, N::Int = 10;
+        weight::Function, lb::Real, ub::Real, N::Integer = 10;
         quadrature::Function = clenshaw_curtis, bnd::Float64 = Inf
     )
     @assert lb < ub "inconsistent interval bounds"
@@ -151,7 +151,7 @@ Node and weight vectors for the associated Gaussian quadrature rule.
 """
 function golubwelsch(
         α::AbstractVector{<:Real}, β::AbstractVector{<:Real},
-        maxiter::Int = 30
+        maxiter::Integer = 30
     )
     N = length(α) - 1
     a, β0 = copy(α[1:N]), β[1]
@@ -164,9 +164,9 @@ end
 golubwelsch(op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}) = golubwelsch(op.α, op.β)
 
 """
-    gauss(N::Int,α::AbstractVector{<:Real},β::AbstractVector{<:Real})
+    gauss(N::Integer,α::AbstractVector{<:Real},β::AbstractVector{<:Real})
     gauss(α::AbstractVector{<:Real},β::AbstractVector{<:Real})
-    gauss(N::Int,op::Union{OrthoPoly,AbstractCanonicalOrthoPoly})
+    gauss(N::Integer,op::Union{OrthoPoly,AbstractCanonicalOrthoPoly})
     gauss(op::Union{OrthoPoly,AbstractCanonicalOrthoPoly})
 
 Gauss quadrature rule, also known as Golub-Welsch algorithm
@@ -194,7 +194,7 @@ with respect to the weight function.
 
 A pair `(nodes, weights)` for the Gaussian quadrature rule.
 """
-function gauss(N::Int, α::AbstractVector{<:Real}, β::AbstractVector{<:Real})
+function gauss(N::Integer, α::AbstractVector{<:Real}, β::AbstractVector{<:Real})
     N += 1
     @assert N > 0 "only positive N allowed"
     @assert length(α) == length(β) "inconsistent number of recurrence coefficients"
@@ -205,14 +205,14 @@ end
 
 gauss(α::AbstractVector{<:Real}, β::AbstractVector{<:Real}) = gauss(length(α) - 1, α, β)
 
-gauss(N::Int, op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}) = gauss(N::Int, op.α, op.β)
+gauss(N::Integer, op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}) = gauss(N::Integer, op.α, op.β)
 
 gauss(op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}) = gauss(op.α, op.β)
 
 """
-    radau(N::Int,α::AbstractVector{<:Real},β::AbstractVector{<:Real},end0::Real)
+    radau(N::Integer,α::AbstractVector{<:Real},β::AbstractVector{<:Real},end0::Real)
     radau(α::AbstractVector{<:Real},β::AbstractVector{<:Real},end0::Real)
-    radau(N::Int,op::Union{OrthoPoly,AbstractCanonicalOrthoPoly},end0::Real)
+    radau(N::Integer,op::Union{OrthoPoly,AbstractCanonicalOrthoPoly},end0::Real)
     radau(op::Union{OrthoPoly,AbstractCanonicalOrthoPoly},end0::Real)
 
 Gauss-Radau quadrature rule.
@@ -242,7 +242,7 @@ interval of w, or outside thereof).
 
 A pair `(nodes, weights)` for the Gauss-Radau rule.
 """
-function radau(N::Int, α::AbstractVector{<:Real}, β::AbstractVector{<:Real}, end0::Real)
+function radau(N::Integer, α::AbstractVector{<:Real}, β::AbstractVector{<:Real}, end0::Real)
     α_ = copy(α)
     @assert N > 0 "only positive N allowed"
     @assert length(α_) == length(β) > 0 "inconsistent number of recurrence coefficients"
@@ -260,7 +260,7 @@ end
 function radau(α::AbstractVector{<:Real}, β::AbstractVector{<:Real}, end0::Real)
     return radau(length(α) - 2, α, β, end0)
 end
-function radau(N::Int, op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}, end0::Real)
+function radau(N::Integer, op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}, end0::Real)
     return radau(N, op.α, op.β, end0)
 end
 function radau(op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}, end0::Real)
@@ -268,9 +268,9 @@ function radau(op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}, end0::Real)
 end
 
 """
-    lobatto(N::Int,α::AbstractVector{<:Real},β::AbstractVector{<:Real},endl::Real,endr::Real)
+    lobatto(N::Integer,α::AbstractVector{<:Real},β::AbstractVector{<:Real},endl::Real,endr::Real)
     lobatto(α::AbstractVector{<:Real},β::AbstractVector{<:Real},endl::Real,endr::Real)
-    lobatto(N::Int,op::Union{OrthoPoly,AbstractCanonicalOrthoPoly},endl::Real,endr::Real)
+    lobatto(N::Integer,op::Union{OrthoPoly,AbstractCanonicalOrthoPoly},endl::Real,endr::Real)
     lobatto(op::Union{OrthoPoly,AbstractCanonicalOrthoPoly},endl::Real,endr::Real)
 
 Gauss-Lobatto quadrature rule.
@@ -302,7 +302,7 @@ resp. to the right thereof).
 A pair `(nodes, weights)` for the Gauss-Lobatto rule.
 """
 function lobatto(
-        N::Int, α_::AbstractVector{<:Real}, β_::AbstractVector{<:Real}, endl::Real,
+        N::Integer, α_::AbstractVector{<:Real}, β_::AbstractVector{<:Real}, endl::Real,
         endr::Real
     )
     α, β = copy(α_), copy(β_)
@@ -334,7 +334,7 @@ function lobatto(
     return lobatto(length(α) - 3, α, β, endl, endr)
 end
 function lobatto(
-        N::Int, op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}, endl::Real,
+        N::Integer, op::Union{OrthoPoly, AbstractCanonicalOrthoPoly}, endl::Real,
         endr::Real
     )
     return lobatto(N, op.α, op.β, endl, endr)

--- a/src/recurrence_coefficients_monic.jl
+++ b/src/recurrence_coefficients_monic.jl
@@ -39,7 +39,7 @@ function r_scale(c::Real, a::AbstractVector{<:Real}, b::AbstractVector{<:Real})
 end
 
 """
-    rm_compute(weight::Function,lb::Real,ub::Real,Npoly::Int=4,Nquad::Int=10;quadrature::Function=clenshaw_curtis)
+    rm_compute(weight::Function,lb::Real,ub::Real,Npoly::Integer=4,Nquad::Integer=10;quadrature::Function=clenshaw_curtis)
 
 Given a positive `weight` function with domain `(lb,ub)`, i.e. a function ``w: [lb, ub ] \\rightarrow \\mathbb{R}_{\\geq 0}``,
 this function creates `Npoly` recursion coefficients `(α,β)`.
@@ -65,7 +65,7 @@ The keyword `quadrature` specifies what quadrature rule is being used.
 A pair `(α, β)` of monic recurrence coefficient vectors.
 """
 function rm_compute(
-        weight::Function, lb::Real, ub::Real, Npoly::Int = 4, Nquad::Int = 10;
+        weight::Function, lb::Real, ub::Real, Npoly::Integer = 4, Nquad::Integer = 10;
         quadrature::Function = clenshaw_curtis,
         discretization::Function = stieltjes
     )
@@ -84,7 +84,7 @@ function rm_compute(
 end
 
 function rm_compute(
-        m::AbstractMeasure, Npoly::Int = 4, Nquad::Int = 10;
+        m::AbstractMeasure, Npoly::Integer = 4, Nquad::Integer = 10;
         quadrature::Function = clenshaw_curtis,
         discretization::Function = stieltjes
     )
@@ -95,7 +95,7 @@ function rm_compute(
 end
 
 ##
-# function rm_logisticsum(n::Int,p1::AbstractVector{<:Real},p2::AbstractVector{<:Real};Mmax::Int=100,eps0::Real=1e-9)
+# function rm_logisticsum(n::Integer,p1::AbstractVector{<:Real},p2::AbstractVector{<:Real};Mmax::Int=100,eps0::Real=1e-9)
 #     M0 = n
 #     Mcap = 0
 #     Mi = M0
@@ -119,7 +119,7 @@ end
 # end
 
 """
-    rm_logistic(N::Int)
+    rm_logistic(N::Integer)
 
 Creates `N` recurrence coefficients for monic polynomials that are orthogonal
 on ``(-\\infty,\\infty)`` relative to ``w(t) = \\frac{\\mathrm{e}^{-t}}{(1 - \\mathrm{e}^{-t})^2}``
@@ -132,15 +132,15 @@ on ``(-\\infty,\\infty)`` relative to ``w(t) = \\frac{\\mathrm{e}^{-t}}{(1 - \\m
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_logistic(N::Int)
+function rm_logistic(N::Integer)
     @assert N >= 0 "parameter(s) out of range."
     N == 0 && return Vector{Float64}(undef, 0), Vector{Float64}(undef, 0)
     return zeros(N), pushfirst!(map(k -> k^4 * pi^2 / (4 * k^2 - 1), Base.OneTo(N - 1)), 1.0)
 end
 
 """
-    rm_hermite(N::Int,mu::Real)
-    rm_hermite(N::Int)
+    rm_hermite(N::Integer,mu::Real)
+    rm_hermite(N::Integer)
 
 Creates `N` recurrence coefficients for monic generalized Hermite polynomials
 that are orthogonal on ``(-\\infty,\\infty)`` relative to ``w(t) = |t|^{2 \\mu} \\mathrm{e}^{-t^2}``
@@ -156,17 +156,17 @@ The call `rm_hermite(N)` is the same as `rm_hermite(N,0)`.
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_hermite(N::Int, mu::Real)
+function rm_hermite(N::Integer, mu::Real)
     @assert N >= 0&&mu > -0.5 "parameter(s) out of range."
     N == 0 && return Array{Float64, 1}(undef, 0), Array{Float64, 1}(undef, 0)
     m0 = mu != 0.0 ? gamma(mu + 0.5) : sqrt(π)
     N == 1 && return [0.0], [m0]
     return zeros(N), pushfirst!(map(x -> isodd(x) ? 0.5 * x + mu : 0.5 * x, 1:(N - 1)), m0)
 end
-rm_hermite(N::Int) = rm_hermite(N, 0.0)
+rm_hermite(N::Integer) = rm_hermite(N, 0.0)
 
 """
-    rm_hermite_prob(N::Int)
+    rm_hermite_prob(N::Integer)
 
 Creates `N` recurrence coefficients for monic probabilists' Hermite polynomials
 that are orthogonal on ``(-\\infty,\\infty)`` relative to ``w(t) = \\mathrm{e}^{-0.5t^2}``
@@ -179,7 +179,7 @@ that are orthogonal on ``(-\\infty,\\infty)`` relative to ``w(t) = \\mathrm{e}^{
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_hermite_prob(N::Int)
+function rm_hermite_prob(N::Integer)
     @assert N >= 0 "parameter(s) out of range."
     N == 0 && return Array{Float64, 1}(undef, 0), Array{Float64, 1}(undef, 0)
     # return zeros(N), [sqrt(2*pi); collect(1.:N-1) ]
@@ -187,8 +187,8 @@ function rm_hermite_prob(N::Int)
 end
 
 """
-    rm_laguerre(N::Int,a::Real)
-    rm_laguerre(N::Int)
+    rm_laguerre(N::Integer,a::Real)
+    rm_laguerre(N::Integer)
 
 Creates `N` recurrence coefficients for monic generalized Laguerre polynomials
 that are orthogonal on ``(0,\\infty)`` relative to ``w(t) = t^a \\mathrm{e}^{-t}``.
@@ -204,7 +204,7 @@ The call `rm_laguerre(N)` is the same as `rm_laguerre(N,0)`.
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_laguerre(N::Int, a::Real)
+function rm_laguerre(N::Integer, a::Real)
     @assert N >= 0&&a > -1.0 "parameter(s) out of range"
     N == 0 && return Array{Float64, 1}(undef, 0), Array{Float64, 1}(undef, 0)
     N == 1 && return [a + 1.0], [gamma(a + 1)]
@@ -212,14 +212,14 @@ function rm_laguerre(N::Int, a::Real)
     return pushfirst!(map(x -> 2x + a + 1.0, n), a + 1.0),
         pushfirst!(map(x -> x^2 + a * x, n), gamma(a + 1))
 end
-function rm_laguerre(N::Int)
+function rm_laguerre(N::Integer)
     return rm_laguerre(N, 0.0)
 end
 
 """
-    rm_jacobi(N::Int,a::Real,b::Real)
-    rm_jacobi(N::Int,a::Real)
-    rm_jacobi(N::Int)
+    rm_jacobi(N::Integer,a::Real,b::Real)
+    rm_jacobi(N::Integer,a::Real)
+    rm_jacobi(N::Integer)
 
 Creates `N` recurrence coefficients for monic Jacobi polynomials
 that are orthogonal on ``(-1,1)`` relative to ``w(t) = (1-t)^a (1+t)^b``.
@@ -236,7 +236,7 @@ The call `rm_jacobi(N,a)` is the same as `rm_jacobi(N,a,a)` and `rm_jacobi(N)` t
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_jacobi(N::Int, a::Real, b::Real)
+function rm_jacobi(N::Integer, a::Real, b::Real)
     @assert N >= 0&&a > -1.0 && b > -1.0 "parameter(s) out of range"
     N == 0 && return Array{Float64, 1}(undef, 0), Array{Float64, 1}(undef, 0)
     nu = (b - a) / (a + b + 2.0)
@@ -256,12 +256,12 @@ function rm_jacobi(N::Int, a::Real, b::Real)
     return A, pushfirst!(pushfirst!(B1 ./ B2, B3), mu)
 end
 
-rm_jacobi(N::Int, a::Real) = rm_jacobi(N, a, a)
-rm_jacobi(N::Int) = rm_jacobi(N, 0.0, 0.0)
+rm_jacobi(N::Integer, a::Real) = rm_jacobi(N, a, a)
+rm_jacobi(N::Integer) = rm_jacobi(N, 0.0, 0.0)
 """
-    rm_jacobi01(N::Int,a::Real,b::Real)
-    rm_jacobi01(N::Int,a::Real)
-    rm_jacobi01(N::Int)
+    rm_jacobi01(N::Integer,a::Real,b::Real)
+    rm_jacobi01(N::Integer,a::Real)
+    rm_jacobi01(N::Integer)
 
 Creates `N` recurrence coefficients for monic Jacobi polynomials
 that are orthogonal on ``(0,1)`` relative to ``w(t) = (1-t)^a t^b``.
@@ -278,17 +278,17 @@ The call `rm_jacobi01(N,a)` is the same as `rm_jacobi01(N,a,a)` and `rm_jacobi01
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_jacobi01(N::Int, a::Real, b::Real)
+function rm_jacobi01(N::Integer, a::Real, b::Real)
     @assert N >= 0&&a > -1.0 && b > -1.0 "parameter(s) out of range"
     N == 0 && return Array{Float64, 1}(undef, 0), Array{Float64, 1}(undef, 0)
     c, d = rm_jacobi(N, a, b)
     return map(x -> (1 + x) / 2, c), pushfirst!(0.25 * d[2:N], d[1] / 2^(a + b + 1.0))
 end
-rm_jacobi01(N::Int, a::Real) = rm_jacobi01(N, a, a)
-rm_jacobi01(N::Int) = rm_jacobi01(N, 0.0, 0.0)
+rm_jacobi01(N::Integer, a::Real) = rm_jacobi01(N, a, a)
+rm_jacobi01(N::Integer) = rm_jacobi01(N, 0.0, 0.0)
 
 """
-    rm_legendre(N::Int)
+    rm_legendre(N::Integer)
 
 Creates `N` recurrence coefficients for monic Legendre polynomials
 that are orthogonal on ``(-1,1)`` relative to ``w(t) = 1``.
@@ -301,10 +301,10 @@ that are orthogonal on ``(-1,1)`` relative to ``w(t) = 1``.
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-rm_legendre(N::Int) = rm_jacobi(N)
+rm_legendre(N::Integer) = rm_jacobi(N)
 
 """
-    rm_legendre01(N::Int)
+    rm_legendre01(N::Integer)
 
 Creates `N` recurrence coefficients for monic Legendre polynomials
 that are orthogonal on ``(0,1)`` relative to ``w(t) = 1``.
@@ -317,11 +317,11 @@ that are orthogonal on ``(0,1)`` relative to ``w(t) = 1``.
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-rm_legendre01(N::Int) = rm_jacobi01(N)
+rm_legendre01(N::Integer) = rm_jacobi01(N)
 
 """
-    rm_meixner_pollaczek(N::Int,lambda::Real,phi::Real)
-    rm_meixner_pollaczek(N::Int,lambda::Real)
+    rm_meixner_pollaczek(N::Integer,lambda::Real,phi::Real)
+    rm_meixner_pollaczek(N::Integer,lambda::Real)
 
 Creates `N` recurrence coefficients for monic
 Meixner-Pollaczek polynomials with parameters λ and ϕ. These are orthogonal on
@@ -339,7 +339,7 @@ The call `rm_meixner_pollaczek(n,lambda)` is the same as `rm_meixner_pollaczek(n
 
 A pair `(α, β)` of recurrence coefficient vectors.
 """
-function rm_meixner_pollaczek(N::Int, lambda::Real, phi::Real)
+function rm_meixner_pollaczek(N::Integer, lambda::Real, phi::Real)
     @assert N >= 0&&lambda > 0.0 && phi > 0.0 "parameter(s) out of range"
     N == 0 && return Array{Float64, 1}(undef, 0), Array{Float64, 1}(undef, 0)
     n = 1:N
@@ -355,7 +355,7 @@ function rm_meixner_pollaczek(N::Int, lambda::Real, phi::Real)
     ab[1, 2] = gamma(lam2) / (2 * sinphi)^lam2
     return ab[:, 1], ab[:, 2]
 end
-rm_meixner_pollaczek(N::Int, lambda::Real) = rm_meixner_pollaczek(N, lambda, pi / 2)
+rm_meixner_pollaczek(N::Integer, lambda::Real) = rm_meixner_pollaczek(N, lambda, pi / 2)
 
 """
     rm_chebyshev1(N)
@@ -371,7 +371,7 @@ polynomials.
 
 The pair `(alpha, beta)` of recurrence coefficient vectors.
 """
-function rm_chebyshev1(N::Int)
+function rm_chebyshev1(N::Integer)
     @assert N >= 0 "N has to be non-negative"
     α = zeros(Float64, N)
     if N == 1
@@ -387,9 +387,9 @@ end
 ###################################################################
 ###################################################################
 
-#     rm_hahn(N::Int,a::Real,b::Real)
-#     rm_hahn(N::Int,a::Real)
-#     rm_hahn(N::Int)
+#     rm_hahn(N::Integer,a::Real,b::Real)
+#     rm_hahn(N::Integer,a::Real)
+#     rm_hahn(N::Integer)
 #
 #  Creates `N` recurrence coefficients for monic Hahn polynomials.
 #
@@ -404,7 +404,7 @@ end
 #     which produces the recurrence coefficients of the discrete
 #     Chebyshev polynomials for the points 0,1,2,...,N.
 # """
-# function rm_hahn(N::Int,a::Real,b::Real)
+# function rm_hahn(N::Integer,a::Real,b::Real)
 #     N-=1
 #     @assert N>=0 && a>=-1. && b>=-1. "parameter(s) out of range"
 #     N==0 ? (return Array{Real,1}(undef,0), Array{Real,1}(undef,0)) : ()
@@ -428,5 +428,5 @@ end
 #     end
 #     return ab[:,1], ab[:,2]
 # end
-# rm_hahn(N::Int,a::Real) = rm_hahn(N,a,a)
-# rm_hahn(N::Int) = rm_hahn(N,0.,0.)
+# rm_hahn(N::Integer,a::Real) = rm_hahn(N,a,a)
+# rm_hahn(N::Integer) = rm_hahn(N,0.,0.)

--- a/src/scalar_product.jl
+++ b/src/scalar_product.jl
@@ -27,7 +27,7 @@ function computeSP(
     ) &&
         throw(InconsistencyError("inconsistent number of recurrence coefficients and/or nodes/weights"))
 
-    a = Vector{Int64}()
+    a = Vector{Int}()
 
     for aa in a_
         !iszero(aa) && push!(a, aa)
@@ -123,7 +123,7 @@ function computeSP(
     minimum(a_) < 0 && throw(DomainError(minimum(a_), "no negative degrees allowed"))
     # this works because ``<Φ_i,Φ_j,Φ_0,...,Φ_0> = <Φ_i,Φ_j>``
     # hence, avoiding unnecessary operations that introduce numerical gibberish
-    # a = Vector{Int64}()
+    # a = Vector{Int}()
     # for aa in a_
     #     !iszero(aa) && push!(a,aa)
     # end

--- a/test/auxfuns.jl
+++ b/test/auxfuns.jl
@@ -24,10 +24,8 @@ mopq = MultiOrthoPoly([opq for i in 1:nunc], d)
 @testset "dimensions" begin
     @test isequal(PolyChaos.dim(op), d + 1)
     @test isequal(PolyChaos.dim(opq), d + 1)
-    @test isequal(
-        PolyChaos.dim(mop),
-        factorial(d + nunc) / (factorial(d) * factorial(nunc))
-    )
+    # binomial avoids OverflowError from factorial(::Int32) for n≥13 on 32-bit
+    @test isequal(PolyChaos.dim(mop), binomial(d + nunc, d))
 end
 
 @testset "degrees" begin

--- a/test/quadrature.jl
+++ b/test/quadrature.jl
@@ -6,7 +6,7 @@ function integration_test(
         tol::Float64 = 1.0e-6,
         dom::Tuple{<:Real, <:Real} = op.measure.dom
     )
-    N, w, ind = op.deg, op.measure.w, zeros(Int64, dim)
+    N, w, ind = op.deg, op.measure.w, zeros(Int, dim)
     return @testset "$name" begin
         for ind_ in Iterators.product([collect(1:N) for i in 1:dim]...)
             ind[:] .= ind_[:]


### PR DESCRIPTION
## Summary
- Change `numberPolynomials(::Int64, ::Int64)` to `::Integer` so it matches `Int` on 32-bit Julia
- Fixes x86 CI `MethodError: no method matching numberPolynomials(::Int32, ::Int32)`

## Test plan
- [ ] Ubuntu x86 Core lane green
- [ ] Existing multi-index tests still pass on x64


Made with [Cursor](https://cursor.com)