### PR TITLE
Release 2.1.2: Integer numberPolynomials (32-bit)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolyChaos"
 uuid = "8d666b04-775d-5f6e-b778-5ac7c70f65a3"
 authors = ["Tillmann Mühlpfordt <tillmann.muehlpfordt@kit.edu>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 AdaptiveRejectionSampling = "c75e803d-635f-53bd-ab7d-544e482d8c75"


### PR DESCRIPTION
## Summary
- #192 widened `numberPolynomials` to `Integer` for i686, but master is still at 2.1.1 so Surrogates x86 cannot resolve the fix.
- Patch bump to 2.1.2 so we can register and unblock Surrogates/`numberPolynomials(::Int32, ::Int32)`.

## Test plan
- [ ] Existing CI green
- [ ] `@JuliaRegistrator register` after merge


Made with [Cursor](https://cursor.com)