### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,42 @@
+using PolyChaos, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+deg = 8
+op = Uniform01OrthoPoly(deg)
+op_g = GaussOrthoPoly(deg)
+op_l = genLaguerreOrthoPoly(deg, 1.2)
+
+x = 0.4
+xs = rand(rng, 500)
+inds = collect(0:deg)
+cf = rand(rng, deg + 1)
+
+# =============================================================================
+# Orthogonal polynomial construction (three-term recurrence coeffs)
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["uniform01"] = @benchmarkable Uniform01OrthoPoly($deg)
+SUITE["construct"]["gauss"] = @benchmarkable GaussOrthoPoly($deg)
+SUITE["construct"]["laguerre"] = @benchmarkable genLaguerreOrthoPoly(
+    $deg, 1.2
+)
+SUITE["construct"]["hermite"] = @benchmarkable GaussOrthoPoly(
+    $deg; addQuadrature = false
+)
+
+# =============================================================================
+# Evaluation / quadrature
+# =============================================================================
+
+SUITE["evaluate"] = @benchmarkable evaluate($inds, $x, $op)
+SUITE["evaluate_batch"] = @benchmarkable evaluate($inds, $xs, $op)
+
+SUITE["quad"] = BenchmarkGroup()
+SUITE["quad"]["fejer"] = @benchmarkable fejer(20)
+SUITE["quad"]["integrate"] = @benchmarkable integrate(x -> sin(π * x), $op)
+SUITE["quad"]["computeSP"] = @benchmarkable computeSP([1, 2], $op)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~12s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~12s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md